### PR TITLE
Install sbt and credentials file for releasing with sbt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -170,6 +170,11 @@ RUN curl -SL --output erlang.deb https://packages.erlang-solutions.com/erlang-so
 RUN apt-get update \
     && apt-get install --assume-yes --no-install-recommends yarn
 
+# Install sbt
+RUN curl -SL --output sbt.deb https://dl.bintray.com/sbt/debian/sbt-1.3.13.deb \
+    && dpkg -i sbt.deb \
+    && rm -f sbt.deb 
+
 USER $USER
 
 ## As a user install node and npm via node version-manager

--- a/Dockerfile
+++ b/Dockerfile
@@ -174,6 +174,8 @@ RUN apt-get update \
 RUN curl -SL --output sbt.deb https://dl.bintray.com/sbt/debian/sbt-1.3.13.deb \
     && dpkg -i sbt.deb \
     && rm -f sbt.deb 
+# Configure sbt
+COPY --chown=$USER sonatype.sbt /home/$USER/.sbt/1.0/sonatype.sbt
 
 USER $USER
 

--- a/sonatype.sbt
+++ b/sonatype.sbt
@@ -1,0 +1,5 @@
+// Sonatype credentials
+credentials += Credentials("Sonatype Nexus Repository Manager", "oss.sonatype.org", "cukebot", sys.env("SONATYPE_PASSWORD"))
+
+// GPG key to sign artifacts
+credentials += Credentials("GnuPG Key ID", "gpg", "E60E1F911B996560FFB135DAF4CABFB5B89B8BE6", "ignored")


### PR DESCRIPTION
The Cucumber Scala project is now using sbt as build tool instead of Maven (see https://github.com/cucumber/cucumber-jvm-scala/issues/139 and https://github.com/cucumber/cucumber-jvm-scala/issues/139).

In order to ease the release process, I would like to add sbt in the cucumber-build image.

FYI I used this new Dockerfile locally to release the 6.9.0 of Cucumber Scala and it worked nice.