### PR TITLE
Add Carton (Perl's Bundler) for local dependency installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ RUN apt-get update \
         g++ \
         jq \
         libc-dev \
+        libssl-dev \
         libxml2-dev \
         libxslt-dev \
         make \
@@ -97,7 +98,9 @@ RUN curl https://bootstrap.pypa.io/get-pip.py | python2 \
 
 # Configure Perl
 RUN curl -L https://cpanmin.us/ -o /usr/local/bin/cpanm \
-    && chmod +x /usr/local/bin/cpanm
+    && chmod +x /usr/local/bin/cpanm \
+    && cpanm --notest Carton \
+    && rm -rf /root/.cpanm
 
 # Install hub
 RUN git clone \


### PR DESCRIPTION
In order to be able to run the tests in the Docker image and install dependencies locally from CPAN, I'd like to extend the image with libssl-dev (in order to be able to build IO::Socket::SSL) and Carton (Perl's Bundler).