### PR TITLE
Add puppeteer dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,49 +60,6 @@ RUN apt-get update \
         wget \
         xmlstarlet
 
-# dependencies for chrome headless
-RUN apt-get update \
-    && apt-get install --assume-yes  \
-        gconf-service \
-        libasound2 \
-        libatk1.0-0 \
-        libatk-bridge2.0-0 \
-        libc6 \
-        libcairo2 \
-        libcups2 \
-        libdbus-1-3 \
-        libexpat1 \
-        libfontconfig1 \
-        libgcc1 \
-        libgconf-2-4 \
-        libgdk-pixbuf2.0-0 \
-        libglib2.0-0 \
-        libgtk-3-0 \
-        libnspr4 \
-        libpango-1.0-0 \
-        libpangocairo-1.0-0 \
-        libstdc++6 \
-        libx11-6 \
-        libx11-xcb1 \
-        libxcb1 \
-        libxcomposite1 \
-        libxcursor1 \
-        libxdamage1 \
-        libxext6 \
-        libxfixes3 \
-        libxi6 \
-        libxrandr2 \
-        libxrender1 \
-        libxss1 \
-        libxtst6 \
-        ca-certificates \
-        fonts-liberation \
-        libappindicator1 \
-        libnss3 \
-        lsb-release \
-        xdg-utils \
-        wget
-
 # Create a cukebot user. Some tools (Bundler, npm publish) don't work properly
 # when run as root
 ENV USER=cukebot
@@ -222,6 +179,22 @@ RUN curl -SL --output sbt.deb https://dl.bintray.com/sbt/debian/sbt-1.3.13.deb \
     && rm -f sbt.deb 
 # Configure sbt
 COPY --chown=$USER sonatype.sbt /home/$USER/.sbt/1.0/sonatype.sbt
+
+# dependencies for chrome headless, wich is required for puppeteer
+# the following has been inspired by https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#running-puppeteer-in-docker
+
+RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+    && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
+    && apt-get update \
+    && apt-get install --assume-yes --no-install-recommends \
+        google-chrome-stable \
+        fonts-ipafont-gothic \
+        fonts-wqy-zenhei \
+        fonts-thai-tlwg \
+        fonts-kacst \
+        fonts-freefont-ttf \
+        libxss1 \
+    && rm -rf /var/lib/apt/lists/*
 
 USER $USER
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -89,7 +89,7 @@ RUN echo "gem: --no-document" > ~/.gemrc \
     && chown -R $USER:$USER /usr/bin
 
 # Install and configure pip2, twine and behave
-RUN curl https://bootstrap.pypa.io/2.7/get-pip.py | python2 \
+RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | python2 \
     && pip install pipenv \
     && pip install twine \
     && pip install behave

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,49 @@ RUN apt-get update \
         wget \
         xmlstarlet
 
+# dependencies for chrome headless
+RUN apt-get update \
+    && apt-get install --assume-yes  \
+        gconf-service \
+        libasound2 \
+        libatk1.0-0 \
+        libatk-bridge2.0-0 \
+        libc6 \
+        libcairo2 \
+        libcups2 \
+        libdbus-1-3 \
+        libexpat1 \
+        libfontconfig1 \
+        libgcc1 \
+        libgconf-2-4 \
+        libgdk-pixbuf2.0-0 \
+        libglib2.0-0 \
+        libgtk-3-0 \
+        libnspr4 \
+        libpango-1.0-0 \
+        libpangocairo-1.0-0 \
+        libstdc++6 \
+        libx11-6 \
+        libx11-xcb1 \
+        libxcb1 \
+        libxcomposite1 \
+        libxcursor1 \
+        libxdamage1 \
+        libxext6 \
+        libxfixes3 \
+        libxi6 \
+        libxrandr2 \
+        libxrender1 \
+        libxss1 \
+        libxtst6 \
+        ca-certificates \
+        fonts-liberation \
+        libappindicator1 \
+        libnss3 \
+        lsb-release \
+        xdg-utils \
+        wget
+
 # Create a cukebot user. Some tools (Bundler, npm publish) don't work properly
 # when run as root
 ENV USER=cukebot
@@ -89,7 +132,7 @@ RUN echo "gem: --no-document" > ~/.gemrc \
     && chown -R $USER:$USER /usr/bin
 
 # Install and configure pip2, twine and behave
-RUN curl https://bootstrap.pypa.io/get-pip.py | python2 \
+RUN curl https://bootstrap.pypa.io/2.7/get-pip.py | python2 \
     && pip install pipenv \
     && pip install twine \
     && pip install behave


### PR DESCRIPTION
`puppeteer` dependencies would allow to execute `html-formatter/javascript` non-regression tests automatically.