### PR TITLE
Continuous Deployment release workflow using restricted branch

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,6 +30,8 @@ jobs:
         with:
           push: true
           platforms: linux/amd64,limux/arm64
-          tags: cucumber/cucumber-build:latest,cucumber/cucumber-build:{{ env.version }}
+          labels:
+            version: ${{ env.version } }
+          tags: cucumber/cucumber-build:latest,cucumber/cucumber-build:${{ env.version }}
       - name: Tag the commit
-        run: git tag {{ env.version }} && git push --tags
+        run: git tag ${{ env.version }} && git push --tags

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,35 @@
+name: Release
+
+on:
+  push:
+    branches: [release]
+
+env:
+  version: 0.4.0
+
+jobs:
+  docker-build:
+    runs-on: ubuntu-latest
+    name: Publish docker image
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          image: tonistiigi/binfmt:latest
+          platforms: all
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+      - uses: docker/build-push-action@v2
+        with:
+          push: true
+          platforms: linux/amd64,limux/arm64
+          tags: cucumber/cucumber-build:latest,cucumber/cucumber-build:{{ env.version }}
+      - name: Tag the commit
+        run: git tag {{ env.version }} && git push --tags

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 NAME      := cucumber/cucumber-build
-VERSION   := pr-12.1
 DEFAULT_PLATFORM = $(shell [ $$(arch) = "arm64" ] && echo "linux/arm64" || echo "linux/amd64")
 PLATFORMS ?= ${DEFAULT_PLATFORM}
 
@@ -12,11 +11,7 @@ local:
 .PHONY: local
 
 docker-push: default
-	[ -d '../secrets' ] || git clone keybase://team/cucumberbdd/secrets ../secrets
-	git -C ../secrets pull
-	. ../secrets/docker-hub-secrets.sh \
-		&& docker login --username $${DOCKER_HUB_USER} --password $${DOCKER_HUB_PASSWORD} \
-		&& docker buildx build --push --platform=${PLATFORMS} --tag ${NAME}:latest --tag ${NAME}:${VERSION} .
+	echo "Deprecated. Please submit a pull request to the `release` branch to have your changes released."
 .PHONY: docker-push
 
 docker-run: local
@@ -27,21 +22,3 @@ docker-run: local
 	  -it ${NAME} \
 	  bash
 .PHONY:
-
-docker-run-with-secrets: default
-	[ -d '../secrets' ]  || git clone keybase://team/cucumberbdd/secrets ../secrets
-	git -C ../secrets pull
-	docker run \
-	  --volume "${shell pwd}":/app \
-	  --volume "${shell pwd}/../secrets/import-gpg-key.sh":/home/cukebot/import-gpg-key.sh \
-	  --volume "${shell pwd}/../secrets/codesigning.key":/home/cukebot/codesigning.key \
-	  --volume "${shell pwd}/../secrets/.ssh":/home/cukebot/.ssh \
-	  --volume "${shell pwd}/../secrets/.gem":/home/cukebot/.gem \
-	  --volume "${shell pwd}/../secrets/.npmrc":/home/cukebot/.npmrc \
-	  --volume "${HOME}/.m2/repository":/home/cukebot/.m2/repository \
-	  --env-file ../secrets/secrets.list \
-	  --user 1000 \
-	  --rm \
-	  -it ${NAME} \
-	  bash
-.PHONY: run-with-secrets

--- a/README.md
+++ b/README.md
@@ -7,30 +7,29 @@ Docker image used to build and release projects in the Cucumber organization.
 In a cucumber project use the `cucumber/cucumber-build:TAG` image to build
 and/or release. You'll find available tags at [Docker Hub](https://hub.docker.com/r/cucumber/cucumber-build/tags).
 
-The secrets needed to make a release can be found in Keybase
-and should be mounted into the docker image. For an example see
-`docker-run-with-secrets` in the `Makefile`.
-
 # Building the image
 
     make
 
-# Pushing a new image
+## Processor Architecture
 
-Before pushing a new image, update `VERSION` in `Makefile`. Then build it again:
+By default, the `make` script will build just for your local host machine's processor architecture, but you can try building for multiple platforms by specifying the PLATFORMS environment variable.
 
-    make
-
-Now start a multi-platform builder:
+Before doing this, make sure you've started a multi-platform builder:
 
     docker buildx create --use
 
-Push the image to [Docker Hub](https://hub.docker.com/r/cucumber/cucumber-build/tags):
+Now try running the build with multiple platforms, e.g.
 
-    make docker-push
+    PLATFORMS=linux/arm64,linux/amd64 make
 
-Make a git tag:
+# Publishing a new version of the image
 
-    git commit -am "Release X.Y.Z"
-    git tag X.Y.Z
-    git push && git push --tags
+The Docker image is published to a public dockerhub repository via an [automated Continuous Deployment workflow](./.github/workflows/release.yaml).
+
+To publish a new version of the image:
+
+1. Update the version number in the [release.yaml](./.github/workflows/release.yaml) workflow.
+1. Update the [CHANGELOG.md](./CHANGELOG.md) file, adding your changes in a section beneath the new release number.
+1. Submit a pull request to the `release` branch.
+1. Wait for a member of the [@cucumber/build](https://github.com/orgs/cucumber/teams/build) team to merge your change and kick off the release.


### PR DESCRIPTION
This change adds a GitHub workflow for making automated releases to DockerHub, via a protected `release` branch.

This is a prototype of what could be a generally applicable strategy for doing automated releases across the Cucumber repos, so it's worth people thinking about this, looking for potential attack vectors and giving their feedback. I've already run through this with @runkalicious.

# Why do we need this?

There are a few weaknesses in our current manual deployment setup:

1. The person doing the release needs to clone the whole secrets repo from keybase onto their hard drive, with the risk that those secrets could subsequently leak off their machine.
2. No auditing of who has done a release, except for manual updates to the changelog.
3. Manual release is prone to human error. New multi-architecture builds have only exacerbated this problem.

This repo does not change very often, so it's not a valuable target for this kind of automation, but it's also a great place to try this out without causing much disruption.

# OK I'm interested, so how does this work?

We have a `release` branch which uses GitHub's [branch protection](https://docs.github.com/en/github/administering-a-repository/about-protected-branches) rules to restrict who can merge to this branch to only the @cucumber/build team.

We have a `Release` [environment](https://docs.github.com/en/actions/reference/environments) that can only be accessed by GitHub Actions workflows running on the `release` branch. This environment contains the secrets needed to publish to dockerhub.

We have a [GitHub Action](https://github.com/cucumber/cucumber-build/blob/c74480d5452218a2e715bdf2e0e1751570a6b5da/.github/workflows/release.yaml) that runs on a push to the `release` branch, and uses those secrets to publish a new container image to dockerhub.

## What are the risks of this approach?

The main risk I see is that a member of the @cucumber/build team merges a change into to the `release` branch that compromises the secrets, such as by loading a script that phones home the secret.

We can mitigate this risk by limiting the number of people who are in this team, and by carefully reviewing each change before release. GitHub allows us to specify policies for protected branches, such as the minimum number of reviewers who have to approve a change. I see this unnecessary for now, but we have it as an option if we want to tighten the screws.

I still see this as a better compromise than the current situation where 21 people have access to all the secrets in keybase.

## Will this replace keybase?

Keybase seems like a good place to have our source of truth, with duplicates of the secrets in protected GitHub environments. If we adopt this strategy, we'll only need to use keybase for reference when cycling these secrets or doing maintenance on the build scripts, so we should be able to greatly reduce the number of people who need access to the whole secrets keybase repo.

Someone with release privileges can merge to a release branch without ever needing to know the secrets being used to make the release, let along having them cloned to their machine.