### PR TITLE
Add symlink for chromium-browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1]
+
+- Add symlink for `chromium-browser` [#31](https://github.com/cucumber/cucumber-build/pull/31)
+
 ## [0.5.0]
 
 - Remove Mono [#28](https://github.com/cucumber/cucumber-build/pull/28)

--- a/Dockerfile
+++ b/Dockerfile
@@ -182,6 +182,8 @@ RUN apt-get update \
 # Download and install chromium for puppetteer
 COPY scripts/download-chrome.sh .
 RUN bash ./download-chrome.sh
+# Puppetteer seems to need the binary to be called chromium-browser
+RUN ln -s /usr/bin/chromium /usr/bin/chromium-browser
 
 # Install Elixir
 ENV MIX_HOME=/home/cukebot/.mix


### PR DESCRIPTION
See cucumber/common#1562 (comment)

Puppetteer seems to need a binary called `chromium-browser`