### PR TITLE
use latest node 12 lts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -207,7 +207,7 @@ RUN curl -sSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.2/install.sh -o
     && export NVM_DIR="$HOME/.nvm" \
     && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
     && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion" \
-    && nvm install 12.16.2 \
+    && nvm install 12.22.1 \
     && nvm install-latest-npm \
     && rm install-nvm.sh
 WORKDIR /app


### PR DESCRIPTION
The Docker image is using Node 12.16.2, but the Node 12 LTS version is now 12.22.1, as used by [the CircleCI `node:12` image](https://hub.docker.com/r/circleci/node/tags?page=1&ordering=last_updated&name=12).

This should fix the build for https://github.com/cucumber/common/pull/1610, where we added a new dependency that is hitting some kind of modules bug with the older Node version (but not the newer one).