### PR TITLE
use nodejs 14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Add Dart [#36](https://github.com/cucumber/build/pull/36)
+- Bump Node version from 12.22.1 to 14.17.3 [#37](https://github.com/cucumber/build/pull/37)
 
 ## [0.5.2]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -214,7 +214,7 @@ RUN curl -sSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.2/install.sh -o
     && export NVM_DIR="$HOME/.nvm" \
     && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
     && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion" \
-    && nvm install 12.22.1 \
+    && nvm install 14.17.3 \
     && nvm install-latest-npm \
     && rm install-nvm.sh
 WORKDIR /app


### PR DESCRIPTION
We should use the current LTS version of Node for our main builds and release process (while also testing on other Node versions for compatibility in the individual library builds).