### PR TITLE
Update Perl dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -101,7 +101,7 @@ RUN curl -sSL https://bootstrap.pypa.io/pip/2.7/get-pip.py -o get-pip.py \
 RUN curl -sSL https://cpanmin.us/ -o /usr/local/bin/cpanm \
     && cd /usr/local/bin/ && echo "09c682a9c6d7c47967bba91909378072921c12d0  cpanm" | sha1sum -c --quiet - && cd /app \
     && chmod +x /usr/local/bin/cpanm \
-    && cpanm --notest Carton \
+    && cpanm --notest Dist::Zilla Test2::V0 \
     && rm -rf /root/.cpanm
 
 # Install hub


### PR DESCRIPTION
# Description

Carton is no longer a dependency; Dist::Zilla is however used to create
the release artifacts and Test2::V0 is used for testing. Making sure these
are installed should speed up the build and the release process.
# Motivation & context

## Type of change

- Refactoring/Updating
