### PR TITLE
Use GHA backend for caching

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,8 +13,6 @@ jobs:
     name: Build docker image
 
     steps:
-      - uses: actions/checkout@v3
-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
         with:
@@ -24,27 +22,13 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
-      - name: Cache Docker layers
-        uses: actions/cache@v2
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-single-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-single-buildx
-
       - name: Build the image
-        run: make
-        env:
-          PLATFORMS: linux/arm64,linux/amd64
-          DOCKER_BUILDKIT: 1
-
-        # Temp fix
-        # https://github.com/docker/build-push-action/issues/252
-        # https://github.com/moby/buildkit/issues/1896
-      - name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+        uses: docker/build-push-action@v2
+        with:
+          platforms: linux/arm64,linux/amd64
+          tags: cucumber/cucumber-build:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Report build failure in Slack
         uses: 8398a7/action-slack@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,28 +14,38 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+
       - name: Read version to release from the changelog
         id: next-release
         uses: cucumber/action-get-versions@v1.0.0
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
         with:
           image: tonistiigi/binfmt:latest
           platforms: all
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
+
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+
       - uses: docker/build-push-action@v2
         with:
           push: true
           platforms: linux/amd64,linux/arm64
           labels: |
             version=${{ steps.next-release.outputs.changelog-latest-version }}
-          tags: cucumber/cucumber-build:latest,cucumber/cucumber-build:${{ steps.next-release.outputs.changelog-latest-version }}
+          tags: |
+            cucumber/cucumber-build:latest,cucumber/cucumber-build
+            ${{ steps.next-release.outputs.changelog-latest-version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
       - uses: cucumber/action-create-github-release@v1.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Rather than writing the cache to a file, this uses Buildkit's support to write directly to the GHA backend.

Because the GHA backend is only available in GHA, the Makefile is not affected. Possibly some of the caching in there could be removed.

The docker/build-push-action doesn't need a checkout, so that is removed in build.yaml. It's left in in release.yaml as I think cucumber/action-get-versions may need it.

The caches aren't scoped because the two actions build with the same options
