### PR TITLE
Add `cpan-upload`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -102,7 +102,7 @@ RUN curl -sSL https://bootstrap.pypa.io/pip/2.7/get-pip.py -o get-pip.py \
 
 # Configure Perl
 RUN apt-get update \
-    && apt-get install --assume-yes cpanminus \
+    && apt-get install --assume-yes cpanminus libcpan-uploader-perl \
     && cpanm --notest Dist::Zilla Test2::V0 \
     && rm -rf /root/.cpanm
 


### PR DESCRIPTION
Dist::Zilla can't upload to CPAN without running tests (as far as I'm aware),
but that doesn't work well with the separation of concerns between the
various Makefile targets we use during the release process (separating testing,
creation of the build archive and uploading the release).
